### PR TITLE
Handle errors to prevent breaking config.

### DIFF
--- a/spoon/Icon.lua
+++ b/spoon/Icon.lua
@@ -38,20 +38,25 @@ end
 ---
 --- Parameters:
 ---  * filePath - The path to the file or application for which to get the icon
-M.macFile = function(filePath)
+M.iconMacFile = function(filePath)
+  if not filePath then
+    hs.printf("⚠️ iconMacFile: filePath is nil")
+    return ""
+  end
+
   local icon = hs.image.iconForFile(filePath)
   if not icon then
-    print("No icon found for file: " .. filePath)
-    return nil
+    hs.printf("⚠️ iconMacFile: no icon found for '%s'", filePath)
+    return ""
   end
-  local pngData = icon:encodeAsURLString(false, "png") -- base64-encoded PNG
+
+  local pngData = icon:encodeAsURLString(false, "png")
   local imgElement = string.format(
     [[<img src="%s" alt="Icon" width="64" height="64">]],
     pngData
   )
   return imgElement
 end
-
 --- GridCraft.Icon.empty() -> string
 --- Function
 --- Create an empty icon, which is a transparent PNG image


### PR DESCRIPTION
So, if you reference applications that don't exist on a given host you'll get errors like this at load:

```
2025-06-02 09:30:40: -- Loading Spoon: GridCraft
2025-06-02 09:30:40: -- Loading extension: spoons
2025-06-02 09:30:40: -- Loading extension: fs
2025-06-02 09:30:40: -- Loading extension: image
2025-06-02 09:30:40: *** ERROR: ...led1/.config/hammerspoon/Spoons/GridCraft.spoon/Icon.lua:39: ERROR: incorrect type 'nil' for argument 1 (expected table or string)
stack traceback:
	[C]: in function 'hs.libimage.iconForFile'
	...led1/.config/hammerspoon/Spoons/GridCraft.spoon/Icon.lua:39: in field 'iconMacFile'
	...d1/.config/hammerspoon/Spoons/GridCraft.spoon/Action.lua:57: in function 'GridCraft.action'
	/Users/josled1/.config/hammerspoon/init.lua:121: in main chunk
	[C]: in function 'xpcall'
	...poon.app/Contents/Resources/extensions/hs/_coresetup.lua:723: in function 'hs._coresetup.setup'
	(...tail calls...)
2025-06-02 09:30:59: -- Loading extension: window
```

The app tries to show an icon that has no local path, and fails. This PR addresses this by gracefully not rendering any icons if it can't find one.

i was REALLY CONFUSED as to why the same code wasn't working between work and personal machines!